### PR TITLE
Add CLI

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+const names = process.argv.slice(2)
+const open = require('open')
+const dedent = require('dedent')
+const getRepo = require('./lib/get-repo')
+
+if (!names.length) {
+  console.log(dedent`To use ghub, specify one or many package names.
+    Examples:
+
+    ghub express
+    ghub choo chai chalk`)
+
+  // exit gracefully to avoid dumping a bunch of npm info
+  process.exit()
+}
+
+
+names.forEach(name => open(getRepo(name)))

--- a/cli.js
+++ b/cli.js
@@ -1,20 +1,32 @@
 #!/usr/bin/env node
 
-const names = process.argv.slice(2)
 const open = require('open')
+const readline = require('readline')
 const dedent = require('dedent')
 const getRepo = require('./lib/get-repo')
 
-if (!names.length) {
-  console.log(dedent`To use ghub, specify one or many package names.
-    Examples:
+if (process.stdin.isTTY) {
+  // Read from arguments
+  const names = process.argv.slice(2)
+  if (!names.length) {
+    console.log(dedent`To use ghub, specify one or many package names.
+      Examples:
 
-    ghub express
-    ghub choo chai chalk`)
+      ghub express
+      ghub choo chai chalk`)
 
-  // exit gracefully to avoid dumping a bunch of npm info
-  process.exit()
+    // exit gracefully to avoid dumping a bunch of npm info
+    process.exit()
+  }
+  names.forEach(name => open(getRepo(name)))
+} else {
+  // Read from newline-delimited STDIN
+  readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+    terminal: false
+  }).on('line', (line) => open(getRepo(line)))
 }
 
 
-names.forEach(name => open(getRepo(name)))
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -676,6 +676,11 @@
       "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
       "dev": true
     },
+    "dedent": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw="
+    },
     "deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
@@ -3392,6 +3397,11 @@
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
+    },
+    "open": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/open/-/open-0.0.5.tgz",
+      "integrity": "sha1-QsPhjslUZra/DcQvOilFw/DK2Pw="
     },
     "optionator": {
       "version": "0.8.2",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,10 @@
   "dependencies": {
     "all-the-package-repos": "^1.2.1",
     "clean-deep": "^3.0.2",
+    "dedent": "^0.7.0",
     "express": "^4.16.2",
-    "lil-env-thing": "^1.0.0"
+    "lil-env-thing": "^1.0.0",
+    "open": "^0.0.5"
   },
   "devDependencies": {
     "chai": "^4.1.2",
@@ -27,5 +29,6 @@
   },
   "engines": {
     "node": 8
-  }
+  },
+  "bin": "cli.js"
 }

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 Redirect to an npm package's GitHub page, if available.
 
-## Usage
+## Web Usage
 
 These links will take you to each package's GitHub repo:
 
@@ -16,6 +16,16 @@ This link redirects to npm, because no GitHub repo will be found for the given p
 
 If you're looking for a quick way to get to an npm package page, use npm's 
 shorter `npm.im` domain, like [npm.im/express](https://npm.im/express).
+
+## CLI Usage
+
+`ghub` is also available as a command-line tool which accepts one or many
+package names and opens their GitHub repos in your web browser:
+
+```sh
+npm i -g ghub
+ghub choo chai chalk
+```
 
 ## Dependencies
 

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,15 @@ npm i -g ghub
 ghub choo chai chalk
 ```
 
+The CLI can also read from newline-delimited standard input. Here's an example
+that opens the repos of the top ten most-dependend-on packages whose names 
+start with `level`:
+
+```sh
+npm i -g ghub all-the-package-names
+all-the-package-names | egrep '^level' | head -n 10 | ghub
+```
+
 ## Dependencies
 
 - [all-the-package-repos](https://github.com/nice-registry/all-the-package-repos): All the repository URLs in the npm registry as an object whose keys are package names and values are URLs

--- a/readme.md
+++ b/readme.md
@@ -30,12 +30,17 @@ ghub choo chai chalk
 ## Dependencies
 
 - [all-the-package-repos](https://github.com/nice-registry/all-the-package-repos): All the repository URLs in the npm registry as an object whose keys are package names and values are URLs
+- [clean-deep](https://github.com/nunofgs/clean-deep): Remove falsy, empty or nullable values from objects
+- [dedent](https://github.com/dmnd/dedent): An ES6 string tag that strips indentation from multi-line strings
 - [express](https://github.com/expressjs/express): Fast, unopinionated, minimalist web framework
+- [lil-env-thing](https://github.com/zeke/lil-env-thing): A tiny convenience module for managing process.env.NODE_ENV
+- [open](https://github.com/pwnall/node-open): open a file or url in the user&#39;s preferred application
 
 ## Dev Dependencies
 
 - [chai](https://github.com/chaijs/chai): BDD/TDD assertion library for node.js and the browser. Test framework agnostic.
 - [mocha](https://github.com/mochajs/mocha): simple, flexible, fun test framework
+- [nodemon](https://github.com/remy/nodemon): Simple monitor script for use during development of a node.js app.
 - [standard](https://github.com/standard/standard): JavaScript Standard Style
 - [standard-markdown](https://github.com/zeke/standard-markdown): Test your Markdown files for Standard JavaScript Style™
 - [supertest](https://github.com/visionmedia/supertest): SuperAgent driven library for testing HTTP servers


### PR DESCRIPTION
I saw that the old ghub had a CLI and assumed it was a tool for doing lookups, but it appears to actually have just been [a way to start the server](https://github.com/juliangruber/ghub.io/blob/f5dffef663588cb0e58e9897553a1f786f808762/bin/ghub.io.js). Is that right, @juliangruber?

Please let me know what you think of this new CLI behavior.