### PR TITLE
prepare to publish version 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghub.io",
-  "private": true,
+  "version": "1.0.0",
   "description": "A nice place for JavaScript packages",
   "main": "server.js",
   "repository": "https://github.com/nice-registry/ghub.io",


### PR DESCRIPTION
Removed the `private` setting, and set version to the current 1.0.0 in anticipation of a major version bump.